### PR TITLE
Fresh copy of #345: Support: add a basic bi-directional mapping utility

### DIFF
--- a/Support/BiMap.swift
+++ b/Support/BiMap.swift
@@ -1,0 +1,55 @@
+
+public struct BiMap<Key: Hashable, Value: Hashable> {
+  public typealias Key = Key
+  public typealias Value = Value
+
+  var keyed: [Key:Value] = [:]
+  // TODO: specialize where value is Int32 such that valued is actually an
+  // array?
+  var valued: [Value:Key] = [:]
+
+  public init(mapping: [Key:Value]) {
+    for (key, value) in mapping {
+      keyed[key] = value
+      valued[value] = key
+    }
+  }
+
+  public mutating func reserveCapacity(_ minimumCapacity: Int) {
+    keyed.reserveCapacity(minimumCapacity)
+    valued.reserveCapacity(minimumCapacity)
+  }
+
+  public var count: Int {
+    assert(keyed.count == valued.count,
+           "keyed count: \(keyed.count), valued count: \(valued.count), \(self)")
+    return keyed.count
+  }
+
+  public subscript(key: Key) -> Value? {
+    get { return keyed[key] }
+    set(value) {
+      guard let value = value else { return }
+      keyed[key] = value
+      valued[value] = key
+    }
+  }
+
+  public subscript(value: Value) -> Key? {
+    get { return valued[value] }
+    set(key) {
+      guard let key = key else { return }
+      keyed[key] = value
+      valued[value] = key
+    }
+  }
+}
+
+extension BiMap: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (Self.Key, Self.Value)...) {
+    for (key, value) in elements {
+      keyed[key] = value
+      valued[value] = key
+    }
+  }
+}

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ModelSupport
+  BiMap.swift
   Checkpoints/CheckpointIndexReader.swift
   Checkpoints/CheckpointReader.swift
   Checkpoints/Protobufs/tensor_bundle.pb.swift


### PR DESCRIPTION
This allows us to map from key or value to their respective inverses.
As this is a common operation, place this into the Support module.